### PR TITLE
Copy data:text/html URLs to the clipboard instead of opening them

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -361,7 +361,18 @@
                 document.getElementById("modal-demo").src = base + submission.demo;
                 document.getElementById("modal-qr").src = base + submission.qr.image;
                 if (submission.qr.type == "Url") {
-                    document.getElementById("modal-qr-anchor").href = submission.qr.url;
+                    const qrAnchor = document.getElementById("modal-qr-anchor")
+                    qrAnchor.removeEventListener("click", window?.qrAnchorClick);
+                    if (submission.qr.url.startsWith('data:text/html')) {
+                        // Browsers do not let you navigate to data urls, so we have to copy the url to the clipboard
+                        qrAnchor.href = "javascript:void(0)";
+                        qrAnchor.addEventListener("click", window.qrAnchorClick = () => {
+                            navigator.clipboard.writeText(submission.qr.url);
+                            alert("Copied URL to clipboard! Paste it into a new tab to view the project.");
+                        })
+                    } else {
+                        qrAnchor.href = submission.qr.url;
+                    }
                 }
 
                 document.getElementById("modal-back").classList.add("open");


### PR DESCRIPTION
You can't navigate to a data URL any other way than pasting it into the URL bar, meaning any `data:text/html` QR codes submitted will not work when clicked. [Currently](https://github.com/24c02/saycheese/blob/5e6415857edf0f46eb956f642e814581862fce94/gallery.html#L363-L365), it just `<a>` links to the data url, but that won't work for `data:text/html` submissions.

This will detect when the data URL is `text/html` and copy it to the clipboard instead of linking to it, with an `alert()` telling you to paste it in a new tab. I did test it :p